### PR TITLE
Remove get_item_definition function and update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is an MCP (Model Context Protocol) server for ArcGIS that provides tools for searching, querying, and recreating ArcGIS Online content. The server authenticates with ArcGIS Online and exposes five main tools:
+This is an MCP (Model Context Protocol) server for ArcGIS that provides tools for searching and querying ArcGIS Online content. The server authenticates with ArcGIS Online and exposes three main tools:
 
 1. `search_layers` - Searches for feature layers by keyword, returns REST URLs
 2. `search_content` - Searches for any content type by keyword, returns Item IDs  
 3. `get_feature_table` - Retrieves attribute data from feature layers as CSV
-4. `get_item_definition` - Retrieves JSON definitions from any content item using Item ID
-5. `recreate_item` - Creates new items from JSON definitions obtained from get_item_definition
 
 ## Architecture
 
@@ -38,10 +36,9 @@ The server requires ArcGIS Online credentials in a `.env` file:
 
 ## Workflows
 
-**Three main workflow patterns:**
+**Main workflow patterns:**
 - `search_layers` → `get_feature_table` (for layer-specific data extraction)
-- `search_content` → `get_item_definition` (for JSON definition analysis)
-- `search_content` → `get_item_definition` → `recreate_item` (for item duplication/recreation)
+- `search_content` → find specific content items by keyword and type
 
 ## Key Implementation Details
 
@@ -50,13 +47,4 @@ The server requires ArcGIS Online credentials in a `.env` file:
 - Multi-layer feature services are handled by iterating through item.layers
 - Content searches can filter by item_type or search all types
 - CSV output excludes geometry for LLM consumption
-- JSON definitions are returned in compact format for efficient LLM processing
-- Different item types require different JSON extraction methods:
-  - Feature Services: Use FeatureLayer(url).properties
-  - Web Maps/Dashboards/Apps: Use item.get_data()
-- Item recreation uses type-specific creation methods:
-  - Web Maps: WebMap(definition).save() with item_properties
-  - Dashboards/Apps: gis.content.add() with text parameter containing JSON
-  - Feature Services: gis.content.create_service() with service_definition
-- The recreate_item tool parses header format: "Item: Title | Type: TYPE | Created: DATE"
 - Error handling returns descriptive error messages as strings

--- a/README.md
+++ b/README.md
@@ -64,21 +64,6 @@ OBJECTID,Name,Type,Status,Install_Date
 2,Hydrant_002,Fire Hydrant,Maintenance,2019-08-22
 ```
 
-### `get_item_definition`
-Retrieves the complete JSON definition of any ArcGIS Online content item using its Item ID.
-
-**Parameters:**
-- `item_id` (string): The Item ID of the content item from search_content results
-
-**Returns:**
-Item metadata header followed by the complete JSON definition in compact format.
-
-**Example:**
-```
-Item: Traffic Dashboard | Type: Dashboard | Created: 1609459200000
-{"widgets":[{"type":"indicator","config":{"dataSource":"layer1"}}],"theme":"dark"}
-```
-
 
 ## Setup
 
@@ -114,10 +99,9 @@ The server is built using the FastMCP framework and leverages the ArcGIS Python 
 
 ## Workflows
 
-### Content Discovery and Analysis
-1. **Search for content**: Use `search_content` to find items by keyword
-2. **Get JSON definitions**: Use `get_item_definition` with Item IDs to analyze service configurations, web map structures, or dashboard layouts
-3. **Extract data**: For feature layers, use `search_layers` to find specific layers, then `get_feature_table` to retrieve attribute data
+### Content Discovery
+1. **Search for content**: Use `search_content` to find items by keyword and type
+2. **Extract data**: For feature layers, use `search_layers` to find specific layers, then `get_feature_table` to retrieve attribute data
 
 ### Layer-Specific Data Extraction
 1. **Find layers**: Use `search_layers` to locate specific feature layers
@@ -127,8 +111,6 @@ The server is built using the FastMCP framework and leverages the ArcGIS Python 
 ## Use Cases
 
 - **Data Discovery**: Find relevant geospatial datasets and applications using natural language queries
-- **Configuration Analysis**: Examine JSON definitions of web maps, dashboards, and services to understand their structure
 - **Spatial Analysis**: Extract attribute data for AI-powered analysis and insights
 - **Report Generation**: Automatically gather data from multiple feature layers for comprehensive reports
-- **Quality Assurance**: Programmatically inspect feature layer contents, metadata, and service configurations
-- **Application Development**: Understand web map and dashboard configurations for building similar applications
+- **Quality Assurance**: Programmatically inspect feature layer contents and service configurations

--- a/main.py
+++ b/main.py
@@ -103,49 +103,6 @@ def search_content(keyword: str, item_type: str = None) -> str:
     except Exception as exc:
         return f"Error searching content: {exc}"
 
-@mcp.tool()
-def get_item_definition(item_id: str) -> str:
-    """Fetches the JSON definition of an ArcGIS Online content item using its Item ID.
-    Args:
-        item_id: The Item ID of the content item from search_content results.
-    Returns:
-        Item metadata header plus the complete JSON definition as a compact string.
-    """
-    try:
-        # Get the item
-        item = gis.content.get(item_id)
-        if not item:
-            return f"Error: Item with ID '{item_id}' not found or not accessible."
-        
-        # Get basic item info
-        title = item.title or "Untitled"
-        item_type = item.type or "Unknown"
-        created = item.created or "Unknown"
-        
-        # Get JSON definition based on item type
-        if item_type in ["Feature Service", "Feature Layer"]:
-            # For feature services, get the service definition
-            if hasattr(item, 'url') and item.url:
-                flayer = FeatureLayer(item.url)
-                definition = flayer.properties
-            else:
-                definition = item.get_data()
-        else:
-            # For web maps, dashboards, apps, etc.
-            definition = item.get_data()
-        
-        if definition is None:
-            return f"Item: {title} | Type: {item_type} | Created: {created}\nNo JSON definition available for this item type."
-        
-        # Format as compact JSON
-        json_str = json.dumps(definition, separators=(',', ':'))
-        
-        # Return with header
-        header = f"Item: {title} | Type: {item_type} | Created: {created}"
-        return f"{header}\n{json_str}"
-        
-    except Exception as exc:
-        return f"Error fetching item definition: {exc}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Remove get_item_definition function from main.py due to token limit issues
- Update CLAUDE.md to reflect 3 remaining tools (search_layers, search_content, get_feature_table)
- Update README.md to remove get_item_definition documentation and references
- Remove workflows and use cases that depended on removed functionality